### PR TITLE
New contributing.rst file

### DIFF
--- a/contributing.rst
+++ b/contributing.rst
@@ -4,16 +4,37 @@
 Contributing
 ============
 
-Flux Framework projects follow the Collective Code Construction Contract (`C4.1 <https://github.com/flux-framework/rfc/blob/master/spec_1.adoc>`_) which describes an optimal collaboration model for open source projects, based on the GitHub fork+pull model.
+The Flux Framework team welcomes all contributors for bug fixes, code improvements, new features, simplifications, documentation, and more. Please do not hesitate to `contact us <https://github.com/orgs/flux-framework/people>`_ with any questions or concerns.
 
-To contribute to a Flux Framework project:
+This guide details how to contribute to `Flux Framework projects <https://github.com/flux-framework>`_ in a standardized and efficient manner. Our projects follow the Collective Code Construction Contract (`C4.1 <https://github.com/flux-framework/rfc/blob/master/spec_1.adoc>`_) which describes an optimal collaboration model for open source projects, based on the GitHub fork+pull model.
 
-* Fork the project.
-* Clone your fork. ``git clone git@github.com:[username]/flux-framework/[project].git``
+.. _pull-requests:
+
+-------------
+Pull Requests
+-------------
+
+Use a pull request (PR) toward a repository's master branch to propose your contribution. If you are planning significant code changes, or have any questions, you can also open an issue before submitting a PR. To contribute to a Flux Framework project:
+
+* `Fork <https://help.github.com/en/github/getting-started-with-github/fork-a-repo>`_ the project.
+* `Clone <https://help.github.com/en/github/getting-started-with-github/fork-a-repo#keep-your-fork-synced>`_ your fork. ``git clone git@github.com:[username]/flux-framework/[project].git``
 * Create a topic branch to contain your change. ``git checkout -b new_feature``
 * Create feature or add fix, and add tests if possible.
 * Make sure everything still passes ``make check``.
-* Rebase your commits into digestible chunks, ideally without errors.
+* Rebase your commits into meaningfully labeled, easily digestible chunks, ideally without errors.
 * Push the branch to your GitHub repo. ``git push origin new_feature``
-* Create a pull request against flux-framework/[project] and describe what your change does and the why you think it should be merged.
-* Each PR will be subjected to automated tests under `travis-ci.org <https://travis-ci.org/>`_
+* Create a PR against flux-framework/[project] and describe what your change does and why you think it should be merged. List any outstanding "to do" items.
+* Each PR will be subjected to automated tests under `travis-ci.org <https://travis-ci.org/>`_.
+
+.. _dev-guidelines:
+
+--------------------
+Developer Guidelines
+--------------------
+
+* Keep the code lean and as simple as possible.
+* Keep the code general and reasonably efficient.
+* Review other issues and PRs to ensure you are not duplicating effort.
+* Update the appropriate `documentation <https://github.com/flux-framework/docs>`_ or open an `issue <https://github.com/flux-framework/docs/issues>`_ to do so.
+
+For more details about C4.1, see LINK TO COME.

--- a/contributing.rst
+++ b/contributing.rst
@@ -1,0 +1,19 @@
+.. _contributing:
+
+============
+Contributing
+============
+
+Flux Framework projects follow the Collective Code Construction Contract (`C4.1 <https://github.com/flux-framework/rfc/blob/master/spec_1.adoc>`_) which describes an optimal collaboration model for open source projects, based on the GitHub fork+pull model.
+
+To contribute to a Flux Framework project:
+
+* Fork the project.
+* Clone your fork. ``git clone git@github.com:[username]/flux-framework/[project].git``
+* Create a topic branch to contain your change. ``git checkout -b new_feature``
+* Create feature or add fix, and add tests if possible.
+* Make sure everything still passes ``make check``.
+* Rebase your commits into digestible chunks, ideally without errors.
+* Push the branch to your GitHub repo. ``git push origin new_feature``
+* Create a pull request against flux-framework/[project] and describe what your change does and the why you think it should be merged.
+* Each PR will be subjected to automated tests under `travis-ci.org <https://travis-ci.org/>`_


### PR DESCRIPTION
This file includes everything from http://flux-framework.org/docs/contributing/ (which I will delete after this page is published) plus additional text and links to flesh out the contributing guidelines a bit more. There's more to do (see issue #1, which is NOT fully resolved by this PR), but I wanted something we could to start with.